### PR TITLE
Introduce `cime_run(ntsteps)`, callable for TSMP-PDAF

### DIFF
--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -4053,6 +4053,11 @@ contains
       ! TSMP specific stop condition:
       counter = counter + 1
       if (present(ntsteps) .and. counter == ntsteps) then
+        if (iamroot_CPLID) then
+          write(logunit,*) ' '
+          write(logunit,103) subname,' NOTE: Stopping from TSMP-PDAF alarm ntsteps'
+          write(logunit,*) ' '
+        endif
         stop_alarm = .true.
       end if
     enddo   ! driver run loop

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -2207,6 +2207,14 @@ contains
     call t_stopf ('CPL:RUN_LOOP_BSTART')
     Time_begin = mpi_wtime()
     Time_bstep = mpi_wtime()
+
+    ! Check for optional input `ntsteps`
+    if(.not. present(ntsteps)) then
+      write(logunit,*) 'ERROR: ntsteps input not present, but needed for TSMP-PDAF ;'
+      call shr_sys_abort(subname// &
+        ' missing ntsteps input that is needed for TSMP-PDAF')
+    end if
+
     do while ( .not. stop_alarm)
 
        call t_startf('CPL:RUN_LOOP', hashint(1))

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -2215,6 +2215,9 @@ contains
         ' missing ntsteps input that is needed for TSMP-PDAF')
     end if
 
+    ! Explicitly set `counter` to zero before loop
+    counter = 0
+
     do while ( .not. stop_alarm)
 
        call t_startf('CPL:RUN_LOOP', hashint(1))

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -177,7 +177,7 @@ module cime_comp_mod
 
   implicit none
 
-  !private
+  private
 
   public cime_pre_init1, cime_pre_init2, cime_init, cime_run, cime_final
   public timing_dir, mpicom_GLOID
@@ -2146,11 +2146,15 @@ contains
   !*******************************************************************************
   !===============================================================================
 
-  subroutine cime_run()
+  subroutine cime_run(ntsteps)
     use seq_comm_mct,   only: atm_layout, lnd_layout, ice_layout, glc_layout,  &
          rof_layout, ocn_layout, wav_layout, esp_layout
     use shr_string_mod, only: shr_string_listGetIndexF
     use seq_comm_mct, only: num_inst_driver
+
+    ! TSMP specific
+    integer, intent(in), optional :: ntsteps
+    integer :: counter=0
 
     ! gptl timer lookup variables
     integer, parameter :: hashcnt=7
@@ -4046,6 +4050,11 @@ contains
           call t_drvstopf   ('CPL:BARRIERALARM',cplrun=.true.)
        endif
 
+      ! TSMP specific stop condition:
+      counter = counter + 1
+      if (present(ntsteps) .and. counter == ntsteps) then
+        stop_alarm = .true.
+      end if
     enddo   ! driver run loop
 
     !|----------------------------------------------------------


### PR DESCRIPTION
1. Re-introduce `private` statement, this was removed because variables from `cime_comp_mod` had to be used by TSMP-PDAF

2. Add `cime_run` with number of time steps `ntsteps` as input. `ntsteps` is supplied by the TSMP-PDAF interface.

3. Add `stop_alarm` for `cime_run` dependent on `ntsteps`.